### PR TITLE
Pantry ingredients intake sad-path tests

### DIFF
--- a/src/pantry.js
+++ b/src/pantry.js
@@ -1,6 +1,16 @@
 class Pantry {
-  constructor(ingredients) {
-    this.ingredients = ingredients;
+  constructor(pantry) {
+    this.ingredients = [];
+    Array.isArray(pantry) ? this.checkIngredients(pantry) : () => {};
+  }
+
+  checkIngredients = (pantry) => {
+    return pantry.forEach(ingredient => {
+      if (typeof ingredient.ingredient === 'number' &&
+        typeof ingredient.amount === 'number') {
+        this.ingredients.push(ingredient);
+      }
+    });
   }
 }
 

--- a/test/pantry-test.js
+++ b/test/pantry-test.js
@@ -4,7 +4,7 @@ const Pantry = require('../src/pantry');
 const usersData = require('../data/users.js');
 
 describe('Pantry', () => {
-  let pantry, pantrySupply;
+  let pantry, pantrySupply, badPantry;
 
   beforeEach(() => {
     pantrySupply = usersData[0].pantry;
@@ -17,5 +17,25 @@ describe('Pantry', () => {
 
   it('should hold a users ingredients', () => {
     expect(pantry.ingredients).to.deep.equal(pantrySupply);
+  });
+
+  it('should only accept arrays as inputs', () => {
+    badPantry = new Pantry('rotten eggs');
+    expect(badPantry.ingredients).to.deep.equal([]);
+  });
+
+  it('should only hold ingredients which are objects', () => {
+    badPantry = new Pantry(['rotten eggs']);
+    expect(badPantry.ingredients).to.deep.equal([]);
+  })
+
+  it('it should only accept ingredients with a number value ingredient key', () => {
+    badPantry = new Pantry([{ingredient:'rotten eggs'}]);
+    expect(badPantry.ingredients).to.deep.equal([]);
+  });
+
+  it("it should only accept ingredients with a number value amount key", () => {
+    badPantry = new Pantry([{ ingredient: 123, amount: 'forty'}]);
+    expect(badPantry.ingredients).to.deep.equal([]);
   });
 });


### PR DESCRIPTION
###### What's this PR do?
Adds sad path testing for `Pantry` which prevents anything but an array with objects with the correct tags from being added to the pantry object.
###### How should this be manually tested?
Can it be broken?
###### Questions:
This approach takes 'error handling' to mean 'error prevention', and ignores *bad* data. Will this cause problems later? 