### PR TITLE
Add way to compare pantry items with recipe reqs

### DIFF
--- a/src/pantry.js
+++ b/src/pantry.js
@@ -1,3 +1,4 @@
+const Recipe = require('./recipe.js');
 class Pantry {
   constructor(pantry) {
     this.ingredients = [];
@@ -11,6 +12,23 @@ class Pantry {
         this.ingredients.push(ingredient);
       }
     });
+  }
+
+  compareIngredients(first, second) {
+    return first.ingredient === second.ingredient ? true : false;
+  }
+
+  checkPantryForRecipeIngredients = (recipe) => {
+    let supplyList = [];
+    
+    for (let i = 0; i < recipe.ingredients.length; i++) {
+      this.ingredients.forEach(ingredient => {
+        if (this.compareIngredients(recipe.ingredients[i], ingredient)) {
+          supplyList.push(ingredient);
+        }
+      }); 
+    }
+    return supplyList
   }
 }
 

--- a/test/pantry-test.js
+++ b/test/pantry-test.js
@@ -1,14 +1,26 @@
 const chai = require('chai');
 const expect = chai.expect;
 const Pantry = require('../src/pantry');
+const Recipe = require('../src/recipe')
 const usersData = require('../data/users.js');
 
 describe('Pantry', () => {
-  let pantry, pantrySupply, badPantry;
+  let pantry, pantrySupply, badPantry, greenHam;
 
   beforeEach(() => {
     pantrySupply = usersData[0].pantry;
     pantry = new Pantry(pantrySupply);
+    greenHam = new Recipe({
+      'id': 12283, 
+      'img':'img', 
+      'ingredients':[
+        {ingredient: 11477, amount: 5}, 
+        {ingredient: 11297, amount: 4}, 
+        {ingredient: 0, amount: 1}
+      ], 
+      "name": "Grandma's Ham", 
+      "tags": ["delicious", "terrifying"]
+    });
   });
 
   it('should be a function', () => {
@@ -29,13 +41,30 @@ describe('Pantry', () => {
     expect(badPantry.ingredients).to.deep.equal([]);
   })
 
-  it('it should only accept ingredients with a number value ingredient key', () => {
+  it('it should only accept ingredients with a number value' +
+  ' ingredient key', () => {
     badPantry = new Pantry([{ingredient:'rotten eggs'}]);
     expect(badPantry.ingredients).to.deep.equal([]);
   });
 
-  it("it should only accept ingredients with a number value amount key", () => {
+  it('it should only accept ingredients with ' + 
+  'a number value amount key', () => {
     badPantry = new Pantry([{ ingredient: 123, amount: 'forty'}]);
     expect(badPantry.ingredients).to.deep.equal([]);
+  });
+
+  it('it should be able to compare check if one ingredients "id" is ' + 
+  'in another array of ingredients', () => {
+    let isTrue = pantry.compareIngredients(pantrySupply[0], greenHam.ingredients[0]);
+    expect(isTrue).to.equal(true); 
+  });
+
+  it('should determine which ingredients a pantry has for a given recipe', () => {
+    const requiredIngredientsInPantry = pantry.checkPantryForRecipeIngredients(greenHam);
+    const expectedIngredients = [
+      { ingredient: 11477, amount: 4 },
+      { ingredient: 11297, amount: 4 },
+    ];
+    expect(requiredIngredientsInPantry).to.deep.equal(expectedIngredients);
   });
 });


### PR DESCRIPTION
###### What's this PR do?
Creates a method which allows the `Pantry` to check which ingredients it contains that are required by a given recipe
###### Where should the reviewer start?
`checkPantryForRecipeIngredients` could probably use a lot of refactoring but also hasn't been sad-path tested yet
###### How should this be manually tested?
*sad path tests
###### Any background context you want to provide?
Mostly making a PR so we can merge and rename some of these redundant `ingredients`