### PR TITLE
Ingredient quantity check

### DIFF
--- a/src/pantry-class.js
+++ b/src/pantry-class.js
@@ -19,24 +19,21 @@ class Pantry {
   compareIngredients(id, ingredient) {
     return id.id === ingredient.ingredient ? true : false;
   }
-  //this has a very obvious sad path of getting used in the wrong order
-  //maybe pantry should change every ingredient key to be ID?
 
   checkPantryForRecipeIngredients = (recipe) => {
-    let supplyList = [];
-    
-    if (recipe instanceof Recipe) {
-      for (let i = 0; i < recipe.requiredIngredients.length; i++) {
-        this.supplies.forEach(ingredient => {
-          if (this.compareIngredients(recipe.requiredIngredients[i], ingredient)) {
-            supplyList.push(ingredient);
-          }
-        }); 
-      }
-      return supplyList
-    } else {
+    if (recipe instanceof Recipe === false) {
       return 'This is not a recipe'
     }
+    let supplyList = [];
+    
+    for (let i = 0; i < recipe.requiredIngredients.length; i++) {
+      this.supplies.forEach(ingredient => {
+        if (this.compareIngredients(recipe.requiredIngredients[i], ingredient)) {
+          supplyList.push(ingredient);
+        }
+      }); 
+    }
+    return supplyList
   }
 
   findIngredientIds = (recipe) => {
@@ -44,11 +41,17 @@ class Pantry {
   } 
 
   findIngredientName(id) {
-    let ingredient = ingredientData.find(item => item.id === id);
-    return ingredient.name;
+    if (typeof id === 'number') {
+      let ingredient = ingredientData.find(item => item.id === id);
+      return ingredient.name;
+    }
   }
-  //TEST 
+
   findMissingIngredients = (recipe) => {
+    if (recipe instanceof Recipe === false) {
+      return 'This is not a recipe'
+    }
+
     let supplyList = this.checkPantryForRecipeIngredients(recipe); 
     let message = [];
     

--- a/src/pantry-class.js
+++ b/src/pantry-class.js
@@ -1,4 +1,6 @@
 const Recipe = require('./recipe-class.js');
+const ingredientData = require('../data/ingredients');
+
 class Pantry {
   constructor(pantry) {
     this.supplies = [];
@@ -14,21 +16,51 @@ class Pantry {
     });
   }
 
-  compareIngredients(first, second) {
-    return first.ingredient === second.ingredient ? true : false;
+  compareIngredients(id, ingredient) {
+    return id.id === ingredient.ingredient ? true : false;
   }
+  //this has a very obvious sad path of getting used in the wrong order
+  //maybe pantry should change every ingredient key to be ID?
 
   checkPantryForRecipeIngredients = (recipe) => {
     let supplyList = [];
     
-    for (let i = 0; i < recipe.requiredIngredients.length; i++) {
-      this.supplies.forEach(ingredient => {
-        if (this.compareIngredients(recipe.requiredIngredients[i], ingredient)) {
-          supplyList.push(ingredient);
-        }
-      }); 
+    if (recipe instanceof Recipe) {
+      for (let i = 0; i < recipe.requiredIngredients.length; i++) {
+        this.supplies.forEach(ingredient => {
+          if (this.compareIngredients(recipe.requiredIngredients[i], ingredient)) {
+            supplyList.push(ingredient);
+          }
+        }); 
+      }
+      return supplyList
+    } else {
+      return 'This is not a recipe'
     }
-    return supplyList
+  }
+
+  findIngredientIds = (recipe) => {
+    return recipe.requiredIngredients.map(ingredient => ingredient.id)
+  } 
+
+  findIngredientName(id) {
+    let ingredient = ingredientData.find(item => item.id === id);
+    return ingredient.name;
+  }
+  //TEST 
+  findMissingIngredients = (recipe) => {
+    let supplyList = this.checkPantryForRecipeIngredients(recipe); 
+    let message = [];
+    
+    recipe.requiredIngredients.forEach(ingredient => {
+      let pantryItem = supplyList.find(item => item.ingredient === ingredient.id);
+      let qtyDifference = pantryItem ? ingredient.amount - pantryItem.amount : ingredient.amount;
+      
+      qtyDifference > 0 ? message.push(`${qtyDifference} ${this.findIngredientName(ingredient.id)}`) : '';
+    });
+    if (message.length > 0) {
+      return `You still need ${message.join(' and ')} to make ${recipe.name}`
+    } 
   }
 }
 

--- a/test/pantry-test.js
+++ b/test/pantry-test.js
@@ -14,9 +14,9 @@ describe('Pantry', () => {
       'id': 12283, 
       'img':'img', 
       'ingredients':[
-        {ingredient: 11477, amount: 5}, 
-        {ingredient: 11297, amount: 4}, 
-        {ingredient: 0, amount: 1}
+        {id: 11477, amount: 5}, 
+        {id: 11297, amount: 4}, 
+        {id: 16069, amount: 1}
       ], 
       "name": "Grandma's Ham", 
       "tags": ["delicious", "terrifying"]
@@ -69,13 +69,21 @@ describe('Pantry', () => {
   });
 
   it('should only check ingredients if the given recipe is a RECIPE', () => {
-      const requiredIngredientsInPantry = pantry.checkPantryForRecipeIngredients(
-        'choppedLiver'
-      );
-      const expectedIngredients = 'This is not a recipe'
-      expect(requiredIngredientsInPantry).to.deep.equal(expectedIngredients);
+    const requiredIngredientsInPantry = pantry.checkPantryForRecipeIngredients(
+      'choppedLiver'
+    );
+    const expectedIngredients = 'This is not a recipe'
+    expect(requiredIngredientsInPantry).to.deep.equal(expectedIngredients);
   });
 
+  it('can find just ingredient ids for a given recipe', () => {
+    let recipeIngredientIds = pantry.findIngredientIds(greenHam);
+    expect(recipeIngredientIds).to.deep.equal([11477, 11297, 16069]);
+  });
   
-
+  it('should know how many ingredients are needed to make a recipe', () => {
+    let missingIngredients = pantry.findMissingIngredients(greenHam);
+    expect(missingIngredients).to.equal('You still need 1 zucchini squash ' +
+    'and 1 legumes to make Grandma\'s Ham')
+  })
 });

--- a/test/pantry-test.js
+++ b/test/pantry-test.js
@@ -67,4 +67,15 @@ describe('Pantry', () => {
     ];
     expect(requiredIngredientsInPantry).to.deep.equal(expectedIngredients);
   });
+
+  it('should only check ingredients if the given recipe is a RECIPE', () => {
+      const requiredIngredientsInPantry = pantry.checkPantryForRecipeIngredients(
+        'choppedLiver'
+      );
+      const expectedIngredients = 'This is not a recipe'
+      expect(requiredIngredientsInPantry).to.deep.equal(expectedIngredients);
+  });
+
+  
+
 });

--- a/test/pantry-test.js
+++ b/test/pantry-test.js
@@ -47,7 +47,7 @@ describe('Pantry', () => {
     expect(badPantry.supplies).to.deep.equal([]);
   });
 
-  it('it should only accept ingredients with ' + 
+  it('should only accept ingredients with ' + 
   'a number value amount key', () => {
     badPantry = new Pantry([{ ingredient: 123, amount: 'forty'}]);
     expect(badPantry.supplies).to.deep.equal([]);
@@ -58,6 +58,13 @@ describe('Pantry', () => {
     let isTrue = pantry.compareIngredients(pantrySupply[0], greenHam.requiredIngredients[0]);
     expect(isTrue).to.equal(true); 
   });
+  
+  it('can compareIngredient IDs whether or not they\'re assigned to ' +
+  '.id or .ingredient', () => {
+    let isTrue = pantry.compareIngredients(greenHam.requiredIngredients[0], pantrySupply[0]);
+    expect(isTrue).to.equal(true); 
+    console.log("I don't know why the last one passed, I don't think it should");
+  })
 
   it('should determine which ingredients a pantry has for a given recipe', () => {
     const requiredIngredientsInPantry = pantry.checkPantryForRecipeIngredients(greenHam);
@@ -81,9 +88,25 @@ describe('Pantry', () => {
     expect(recipeIngredientIds).to.deep.equal([11477, 11297, 16069]);
   });
   
+  it('can find an ingredient\'s name from its Id', () => {
+    let name = pantry.findIngredientName(16069);
+    expect(name).to.equal('legumes');
+  });
+
+  it('won\'t search for IDs that aren\'t numbers', () => {
+    let name = pantry.findIngredientName('legumes');
+    expect(name).to.equal(undefined);
+  })
+
   it('should know how many ingredients are needed to make a recipe', () => {
     let missingIngredients = pantry.findMissingIngredients(greenHam);
     expect(missingIngredients).to.equal('You still need 1 zucchini squash ' +
     'and 1 legumes to make Grandma\'s Ham')
+  });
+
+  it('won\'t check for missing ingredients if not provided with a recipe', () => {
+    let missingIngredients = pantry.findMissingIngredients('rotten eggs');
+    expect(missingIngredients).to.equal('This is not a recipe');
   })
+
 });


### PR DESCRIPTION
###### What's this PR do?
* Adds the method `pantry.findMissingIngredients()` which returns a sentence explaining what ingredients and how many you're missing in order to cook a given recipe.
###### Where should the reviewer start?
* I'm very surprised the `compareIngredients` helper is passing both tests (there's a `console.log` marking the surprising one.)
###### How should this be manually tested?
* Download it and run `npm test`. Recommend more sad-paths if you see them.
###### Any background context you want to provide?
This feature does not utilize `pantry.checkPantryForRecipeIngredients` as expected, and potentially provides an alternative way of approaching that method. However, given the overlap of these two methods and their complete independence of one another, I think we should consider why, how, and if we should be using both of them given that (I believe) they were both outlined in the comp. 
###### Questions:
* The `compareIngredients` method highlights the danger of having one set of data (`usersData`) which refers to `ingredient.id` as `ingredient.ingredient` - should the `User` class alter this tag when instantiating new `user` objects?